### PR TITLE
Catch "TypeError" on char read to map EOF to "0" codepoint

### DIFF
--- a/potatoes.py
+++ b/potatoes.py
@@ -391,7 +391,10 @@ def _input_statement(reader):
             if x is trigger_a:
                 env.var_a = int(input())
             elif x is trigger_b:
-                env.var_a = ord(sys.stdin.read(1))
+                try:
+                    env.var_a = ord(sys.stdin.read(1))
+                except TypeError:
+                    env.var_a = 0
             else:
                 raise SemanticError("Invalid trigger passed")
         with env.label.bind(label, trigger):


### PR DESCRIPTION
Using a "0" value for the input on an end of file condition allows code to handle that scenario.